### PR TITLE
Re-export embassy_time, upgrade dependencies (WIP)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,12 @@ defmt = { version = "^1.0.1", optional = true }
 heapless = "0.9.1"
 
 # trouble bluetooth dependencies
-nrf-sdc = { version = "0.3", default-features = false, features = [
+nrf-sdc = { git = "https://github.com/alexmoon/nrf-sdc.git", rev = "d4d244d5ce21f59fa2263333cb1d8f2a5d997145", default-features = false, features = [
     "defmt",
     "peripheral",
     "nrf52833",
 ], optional = true }
-nrf-mpsl = { version = "0.3", default-features = false, features = [
+nrf-mpsl = { git = "https://github.com/alexmoon/nrf-sdc.git", rev = "d4d244d5ce21f59fa2263333cb1d8f2a5d997145", default-features = false, features = [
     "defmt",
     "critical-section-impl",
 ], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,30 +10,30 @@ repository = "https://github.com/lulf/microbit-bsp"
 rust-version = "1.83"
 
 [dependencies]
-embassy-nrf = { version = "0.4.1", features = [
+embassy-nrf = { version = "0.9.0", features = [
     "gpiote",
     "nfc-pins-as-gpio",
     "nrf52833",
     "time-driver-rtc1",
     "time",
 ] }
-embassy-time = { version = "0.4", default-features = false }
-embassy-sync = { version = "0.7.0" }
-cortex-m = { version = "0.7.6" }
+embassy-time = { version = "0.5", default-features = false }
+embassy-sync = { version = "0.7.2" }
+cortex-m = { version = "0.7.7" }
 embedded-hal = "1.0"
 lsm303agr = { version = "1.1.0", features = ["async"] }
 futures = { version = "0.3", default-features = false }
 
 defmt = { version = "^1.0.1", optional = true }
-heapless = "0.8.0"
+heapless = "0.9.1"
 
 # trouble bluetooth dependencies
-nrf-sdc = { version = "0.1", default-features = false, features = [
+nrf-sdc = { version = "0.3", default-features = false, features = [
     "defmt",
     "peripheral",
     "nrf52833",
 ], optional = true }
-nrf-mpsl = { version = "0.1", default-features = false, features = [
+nrf-mpsl = { version = "0.3", default-features = false, features = [
     "defmt",
     "critical-section-impl",
 ], optional = true }
@@ -44,7 +44,7 @@ default = ["defmt"]
 defmt = [
     "dep:defmt",
     "embassy-nrf/defmt",
-    "heapless/defmt-03",
+    "heapless/defmt",
     "embassy-time/defmt",
     "embassy-time/defmt-timestamp-uptime",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microbit-bsp"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "An embassy-based boards support package (BSP) for BBC Micro:bit v2"
 license = "MIT OR Apache-2.0"

--- a/examples/accelerometer/Cargo.toml
+++ b/examples/accelerometer/Cargo.toml
@@ -7,13 +7,12 @@ edition = "2021"
 microbit-bsp = { path = "../../" }
 
 embassy-futures = { version = "0.1.1", default-features = false }
-embassy-executor = { version = "0.7", default-features = false, features = [
-    "arch-cortex-m", 
-    "defmt", 
-    "executor-interrupt", 
+embassy-executor = { version = "0.9", default-features = false, features = [
+    "arch-cortex-m",
+    "defmt",
+    "executor-interrupt",
     "executor-thread"
 ] }
-embassy-time = { version = "0.4", default-features = false, features = ["defmt-timestamp-uptime", "defmt"] }
 
 cortex-m-rt = "0.7"
 

--- a/examples/accelerometer/src/main.rs
+++ b/examples/accelerometer/src/main.rs
@@ -3,10 +3,10 @@
 
 use defmt::{info, Debug2Format};
 use embassy_executor::Spawner;
-use embassy_time::Duration;
 use microbit_bsp::{
     display::{Brightness, Frame},
     embassy_nrf::{bind_interrupts, peripherals::TWISPI0, twim::InterruptHandler},
+    embassy_time::Duration,
     motion::Sensor,
     LedMatrix, Microbit,
 };

--- a/examples/ble-nrf-softdevice/Cargo.toml
+++ b/examples/ble-nrf-softdevice/Cargo.toml
@@ -7,12 +7,11 @@ edition = "2021"
 microbit-bsp = { path = "../../" }
 
 embassy-futures = { version = "0.1.1", default-features = false }
-embassy-executor = { version = "0.7", default-features = false, features = [
-    "arch-cortex-m", 
-    "defmt", 
+embassy-executor = { version = "0.9", default-features = false, features = [
+    "arch-cortex-m",
+    "defmt",
     "executor-thread"
 ] }
-embassy-time = { version = "0.4", default-features = false, features = ["defmt-timestamp-uptime"] }
 
 nrf-softdevice = { version = "0.1.0", features = ["ble-peripheral", "ble-gatt-server", "s113", "nrf52833", "critical-section-impl", "defmt"] }
 nrf-softdevice-s113 = { version = "0.1.2" }

--- a/examples/ble-trouble/Cargo.toml
+++ b/examples/ble-trouble/Cargo.toml
@@ -5,19 +5,18 @@ edition = "2021"
 resolver = "2"
 
 [dependencies]
-embassy-executor = { version = "0.7", default-features = false, features = [
-    "arch-cortex-m", 
-    "defmt", 
-    "executor-interrupt", 
+embassy-executor = { version = "0.9", default-features = false, features = [
+    "arch-cortex-m",
+    "defmt",
+    "executor-interrupt",
     "executor-thread"
     ] }
-embassy-time = { version = "0.4", default-features = false, features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-futures = "0.1.1"
 embassy-sync = { version = "0.7", features = ["defmt"] }
 microbit-bsp = { path = "../../", features = ["trouble"]}
 
 futures = { version = "0.3", default-features = false, features = ["async-await"]}
-trouble-host = { version = "0.2.0", features = ["defmt", "gatt", "peripheral"] }
+trouble-host = { version = "0.5", features = ["defmt", "gatt", "peripheral"] }
 
 defmt = "1.0.1"
 defmt-rtt = "1"

--- a/examples/display/Cargo.toml
+++ b/examples/display/Cargo.toml
@@ -7,13 +7,12 @@ edition = "2021"
 microbit-bsp = { path = "../../" }
 
 embassy-futures = { version = "0.1.1", default-features = false }
-embassy-executor = { version = "0.7.0", default-features = false, features = [
-    "arch-cortex-m", 
-    "defmt", 
-    "executor-interrupt", 
+embassy-executor = { version = "0.9", default-features = false, features = [
+    "arch-cortex-m",
+    "defmt",
+    "executor-interrupt",
     "executor-thread"
 ] }
-embassy-time = { version = "0.4.0", default-features = false, features = ["defmt-timestamp-uptime", "defmt"] }
 
 cortex-m-rt = "0.7"
 

--- a/examples/display/src/main.rs
+++ b/examples/display/src/main.rs
@@ -3,8 +3,7 @@
 
 use embassy_executor::Spawner;
 use embassy_futures::select::{select, Either};
-use embassy_time::Duration;
-use microbit_bsp::*;
+use microbit_bsp::{*, embassy_time::Duration};
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]

--- a/examples/magnetometer/Cargo.toml
+++ b/examples/magnetometer/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2021"
 microbit-bsp = { path = "../../" }
 
 embassy-futures = { version = "0.1.1", default-features = false }
-embassy-executor = { version = "0.7", default-features = false, features = ["defmt", "arch-cortex-m", "executor-thread", "executor-interrupt"] }
-embassy-time = { version = "0.4", default-features = false, features = ["defmt-timestamp-uptime", "defmt"] }
+embassy-executor = { version = "0.9", default-features = false, features = ["defmt", "arch-cortex-m", "executor-thread", "executor-interrupt"] }
 
 cortex-m-rt = "0.7"
 

--- a/examples/magnetometer/src/main.rs
+++ b/examples/magnetometer/src/main.rs
@@ -4,10 +4,10 @@
 use core::f32::consts::PI;
 use defmt::{debug, info, Debug2Format};
 use embassy_executor::Spawner;
-use embassy_time::{Duration, Timer};
 use microbit_bsp::{
     display::{Brightness, Frame},
     embassy_nrf::{bind_interrupts, peripherals::TWISPI0, twim::InterruptHandler},
+    embassy_time::{self, Duration, Timer},
     lsm303agr,
     motion::new_lsm303agr,
     Microbit,

--- a/examples/microphone/Cargo.toml
+++ b/examples/microphone/Cargo.toml
@@ -7,16 +7,12 @@ edition = "2021"
 microbit-bsp = { path = "../../" }
 
 embassy-futures = { version = "0.1", default-features = false }
-embassy-executor = { version = "0.7", default-features = false, features = [
+embassy-executor = { version = "0.9", default-features = false, features = [
     "arch-cortex-m",
     "defmt",
     "executor-interrupt",
     "executor-thread",
     "task-arena-size-32768",
-] }
-embassy-time = { version = "0.4", default-features = false, features = [
-    "defmt-timestamp-uptime",
-    "defmt",
 ] }
 
 cortex-m-rt = "0.7"

--- a/examples/microphone/src/main.rs
+++ b/examples/microphone/src/main.rs
@@ -7,10 +7,10 @@
 
 use defmt::info;
 use embassy_executor::Spawner;
-use embassy_time::Duration;
 use microbit_bsp::{
     display::{Brightness, Frame},
     embassy_nrf::{bind_interrupts, saadc::InterruptHandler},
+    embassy_time::Duration,
     mic::Microphone,
     LedMatrix, Microbit,
 };

--- a/examples/speaker/Cargo.toml
+++ b/examples/speaker/Cargo.toml
@@ -7,13 +7,12 @@ edition = "2021"
 microbit-bsp = { path = "../../" }
 
 embassy-futures = { version = "0.1.1", default-features = false }
-embassy-executor = { version = "0.7", default-features = false, features = [
-    "arch-cortex-m", 
-    "defmt", 
-    "executor-interrupt", 
-    "executor-thread", 
+embassy-executor = { version = "0.9", default-features = false, features = [
+    "arch-cortex-m",
+    "defmt",
+    "executor-interrupt",
+    "executor-thread",
 ] }
-embassy-time = { version = "0.4", default-features = false, features = ["defmt-timestamp-uptime", "defmt"] }
 
 cortex-m-rt = "0.7"
 

--- a/examples/speaker/src/main.rs
+++ b/examples/speaker/src/main.rs
@@ -2,9 +2,9 @@
 #![no_main]
 
 use embassy_executor::Spawner;
-use embassy_time::Timer;
 use microbit_bsp::{
-    embassy_nrf::pwm::SimplePwm,
+    embassy_nrf::pwm::{SimplePwm, SimpleConfig},
+    embassy_time::Timer,
     speaker::{NamedPitch, Note, PwmSpeaker},
     Microbit,
 };
@@ -39,7 +39,8 @@ const TUNE: [(NamedPitch, u32); 18] = {
 async fn main(_s: Spawner) {
     let board = Microbit::default();
     defmt::info!("Application started!");
-    let mut speaker = PwmSpeaker::new(SimplePwm::new_1ch(board.pwm0, board.speaker));
+    let config = SimpleConfig::default();
+    let mut speaker = PwmSpeaker::new(SimplePwm::new_1ch(board.pwm0, board.speaker, &config));
     loop {
         defmt::info!("Playing tune!");
         for (pitch, ticks) in TUNE {

--- a/src/ble.rs
+++ b/src/ble.rs
@@ -136,7 +136,7 @@ where
             mpsl::MultiprotocolServiceLayer::new(p, Irqs, Self::LF_CLOCK_CONFIG)
         }?;
         let sdc_rng = {
-            static SDC_RNG: StaticCell<rng::Rng<'static, peripherals::RNG, Async>> = StaticCell::new();
+            static SDC_RNG: StaticCell<rng::Rng<'static, Async>> = StaticCell::new();
             SDC_RNG.init(rng::Rng::new(rng, Irqs))
         };
         let mem = {
@@ -155,7 +155,7 @@ where
 /// Build the Softdevice Controller layer to pass to trouble-host
 fn build_sdc<'d, const N: usize>(
     p: nrf_sdc::Peripherals<'d>,
-    rng: &'d mut rng::Rng<peripherals::RNG, Async>,
+    rng: &'d mut rng::Rng<'d, Async>,
     mpsl: &'d MultiprotocolServiceLayer,
     mem: &'d mut sdc::Mem<N>,
 ) -> Result<nrf_sdc::SoftdeviceController<'d>, nrf_sdc::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod speaker;
 // Re-exports
 
 pub use embassy_nrf;
+pub use embassy_time;
 pub use lsm303agr;
 
 #[cfg(feature = "trouble")]

--- a/src/motion/mod.rs
+++ b/src/motion/mod.rs
@@ -16,7 +16,7 @@ use lsm303agr::{
 };
 use static_cell::ConstStaticCell;
 
-type I2C<'d> = twim::Twim<'d, TWISPI0>;
+type I2C<'d> = twim::Twim<'d>;
 
 /// Accelerometer error
 pub type Error = LsmError<twim::Error>;

--- a/src/speaker.rs
+++ b/src/speaker.rs
@@ -147,13 +147,13 @@ impl From<NamedPitch> for Pitch {
 pub struct Note(pub Pitch, pub u32);
 
 /// PWM based speaker capable of playing notes with a given pitch
-pub struct PwmSpeaker<'a, T: pwm::Instance> {
-    pwm: pwm::SimplePwm<'a, T>,
+pub struct PwmSpeaker<'a> {
+    pwm: pwm::SimplePwm<'a>,
 }
 
-impl<'a, T: pwm::Instance> PwmSpeaker<'a, T> {
+impl<'a> PwmSpeaker<'a> {
     /// Create a new speaker instance
-    pub fn new(pwm: pwm::SimplePwm<'a, T>) -> Self {
+    pub fn new(pwm: pwm::SimplePwm<'a>) -> Self {
         Self { pwm }
     }
 
@@ -161,7 +161,7 @@ impl<'a, T: pwm::Instance> PwmSpeaker<'a, T> {
         self.pwm.set_prescaler(pwm::Prescaler::Div4);
         self.pwm.set_period(frequency);
         self.pwm.enable();
-        self.pwm.set_duty(0, self.pwm.max_duty() / 2);
+        self.pwm.set_duty(0, pwm::DutyCycle::normal(self.pwm.max_duty() / 2));
     }
 
     fn stop_play(&mut self) {


### PR DESCRIPTION
Re-exports the `embassy_time` crate to avoid resolver errors. Upgrades all dependencies and fix resulting breakage. Bumps the version to 0.5.0 because breaking changes.

This PR depends on embassy-rs/embassy#5160 and should wait until that is upstreamed.